### PR TITLE
Chained swupd servers, auto catalog detection

### DIFF
--- a/build/etc/init.d/applianceFirstRun
+++ b/build/etc/init.d/applianceFirstRun
@@ -28,6 +28,22 @@ case "$1" in
 
 		#Point Apache to SUS
 		sed -i "s/DocumentRoot.*/DocumentRoot \/srv\/SUS\/html\//g" /etc/apache2/sites-enabled/000-default
+		sed -i "s|</VirtualHost>||" /etc/apache2/sites-enabled/000-default
+		cat >>/etc/apache2/sites-enabled/000-default <<ZHEREDOC
+    <IfModule mod_rewrite.c>
+        RewriteEngine On
+        RewriteCond %{HTTP_USER_AGENT} Darwin/9
+        RewriteRule ^/index\.sucatalog$ http://%{HTTP_HOST}/content/catalogs/others/index-leopard.merged-1.sucatalog
+        RewriteCond %{HTTP_USER_AGENT} Darwin/10
+        RewriteRule ^/index\.sucatalog$ http://%{HTTP_HOST}/content/catalogs/others/index-leopard-snowleopard.merged-1.sucatalog
+        RewriteCond %{HTTP_USER_AGENT} Darwin/11
+        RewriteRule ^/index\.sucatalog$ http://%{HTTP_HOST}/content/catalogs/others/index-lion-snowleopard-leopard.merged-1.sucatalog
+        RewriteCond %{HTTP_USER_AGENT} Darwin/12
+        RewriteRule ^/index\.sucatalog$ http://%{HTTP_HOST}/content/catalogs/others/index-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog
+    </IfModule>
+
+</VirtualHost>
+ZHEREDOC
 
 		#Remove default it works page
 		rm /var/www/index.html		
@@ -73,6 +89,7 @@ unix extensions = no' /etc/samba/smb.conf > /tmp/smb.conf
 
 		# Enable apache on SSL
 		a2enmod ssl
+		a2enmod rewrite
 		a2ensite default-ssl
 		/etc/init.d/apache2 restart
 

--- a/build/var/appliance/sus_sync.py
+++ b/build/var/appliance/sus_sync.py
@@ -81,6 +81,7 @@ def sync_sus():
     os.system("cp /srv/SUS/html/content/catalogs/others/index-leopard.merged-1_" + strRootBranch + ".sucatalog /srv/SUS/html/index-leopard.merged-1.sucatalog")
     os.system("cp /srv/SUS/html/content/catalogs/others/index-lion-snowleopard-leopard.merged-1_" + strRootBranch + ".sucatalog /srv/SUS/html/index-lion-snowleopard-leopard.merged-1.sucatalog")
     os.system("cp /srv/SUS/html/content/catalogs/others/index-leopard-snowleopard.merged-1_" + strRootBranch + ".sucatalog /srv/SUS/html/index-leopard-snowleopard.merged-1.sucatalog")
+    os.system("cp /srv/SUS/html/content/catalogs/others/index-mountainlion-lion-snowleopard-leopard.merged-1_" + strRootBranch + ".sucatalog /srv/SUS/html/index-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog")
     os.system("cp /srv/SUS/html/content/catalogs/index_" + strRootBranch + ".sucatalog /srv/SUS/html/index.sucatalog")
 
 def enable_all_sus():
@@ -91,6 +92,7 @@ def enable_all_sus():
     os.system("cp /srv/SUS/html/content/catalogs/others/index-leopard.merged-1_" + strRootBranch + ".sucatalog /srv/SUS/html/index-leopard.merged-1.sucatalog")
     os.system("cp /srv/SUS/html/content/catalogs/others/index-lion-snowleopard-leopard.merged-1_" + strRootBranch + ".sucatalog /srv/SUS/html/index-lion-snowleopard-leopard.merged-1.sucatalog")
     os.system("cp /srv/SUS/html/content/catalogs/others/index-leopard-snowleopard.merged-1_" + strRootBranch + ".sucatalog /srv/SUS/html/index-leopard-snowleopard.merged-1.sucatalog")
+    os.system("cp /srv/SUS/html/content/catalogs/others/index-mountainlion-lion-snowleopard-leopard.merged-1_" + strRootBranch + ".sucatalog /srv/SUS/html/index-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog")
     os.system("cp /srv/SUS/html/content/catalogs/index_" + strRootBranch + ".sucatalog /srv/SUS/html/index.sucatalog")
 
 try:

--- a/build/var/www/webadmin/scripts/adminHelper.sh
+++ b/build/var/www/webadmin/scripts/adminHelper.sh
@@ -247,7 +247,7 @@ sususage)
 du -h /srv/SUS | tail -1 | awk '{print $1}'
 ;;
 lastsussync)
-echo `ls -al /srv/SUS/html/content/catalogs/ | grep index.sucatalog | head -1 | awk '{print $6" "$7}'`
+echo `ls -lt /srv/SUS/html/content/catalogs/ /srv/SUS/html/content/catalogs/others/ | grep '\.sucatalog$' | head -1 | awk '{print $6" "$7}'`
 ;;
 afpconns)
 echo `netstat | grep afpovertcp | wc | awk '{print $1}'`


### PR DESCRIPTION
Added support for chained swupd servers, Mountain Lion and dynamic OS catalog detection.
Enabled mod_rewrite on appliance and added rules for Darwin/9 to
Darwin/12 to http config;
Modified rule for determining last update date as there is no default catalog when getting catalogues off another swupd server
