### PR TITLE
fixed issue: makeself/makeself.sh: line 262: test: too many arguments

### DIFF
--- a/makeself/makeself.sh
+++ b/makeself/makeself.sh
@@ -259,7 +259,7 @@ else
 
     LABEL="$3"
     SCRIPT="$4"
-    test x$SCRIPT = x || shift 1
+    test "x$SCRIPT" = "x" || shift 1
     shift 3
     SCRIPTARGS="$*"
 fi


### PR DESCRIPTION
Getting an error when running the CreateNetSUSInstaller.sh due to forth parameter having a quote string with spaces:
bash makeself/makeself.sh temp/base/ NetSUSInstaller.run "NetSUS Installer" "bash NetSUSInstaller.sh"

```
SCRIPT="$4"
test x$SCRIPT = x || shift 1
```

test line produces error: makeself/makeself.sh: line 262: test: too many arguments
