### PR TITLE
Adding a binary test for Ubuntu

### DIFF
--- a/base/NetSUSInstaller.sh
+++ b/base/NetSUSInstaller.sh
@@ -38,6 +38,7 @@ failedAnyChecks=0
 
 logEvent $detectedOS
 
+[[ $detectedOS == "Ubuntu" ]] && { bash testUbuntuBinRequirements.sh; }
 
 # Check for a 64-bit OS
 bash test64bitRequirements.sh 

--- a/base/testUbuntuBinRequirements.sh
+++ b/base/testUbuntuBinRequirements.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+source logger.sh
+
+logEventNoNewLine "Checking for required Ubuntu binaries"
+
+# checking for policycoreutils
+pcucheck=`dpkg -s policycoreutils | awk '/Package: / {print $2}'`
+[[ "${pcucheck}" != "policycoreutils" ]] && { sudo apt-get install policycoreutils; }
+
+# checking for gawk
+pcucheck=`dpkg -s gawk | awk '/Package: / {print $2}'`
+[[ "${pcucheck}" != "gawk" ]] && { sudo apt-get install gawk; }
+
+exit 0


### PR DESCRIPTION
checks to see if policycoreutils and gawk are installed, if not install
them.