### PR TITLE
Change to make the "Select All" button work

### DIFF
--- a/webadmin/etc/php5/apache2/php.ini
+++ b/webadmin/etc/php5/apache2/php.ini
@@ -453,6 +453,10 @@ max_input_time = 3600
 ; http://php.net/max-input-nesting-level
 ;max_input_nesting_level = 64
 
+; How many GET/POST/COOKIE input variables may be accepted
+ max_input_vars = 10000
+
+
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
 memory_limit = 128M


### PR DESCRIPTION
This change makes the "select all" button work in various branches. Before this change the variable is not set when installed, and so the select all button fails to actually do anything. 

Referencing problem #54, resolution posted by @kev111
