### PR TITLE
update branchURL for Sierra and High Sierra

### DIFF
--- a/docs/sus.md
+++ b/docs/sus.md
@@ -125,6 +125,14 @@ Branch URLs vary depending on the operating system of enrolled computers. Exampl
 
 	http://sus.mycompany.corp/content/catalogs/others/index-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1_<Branch Name>.sucatalog
 	
+**OS X v10.12**
+
+    https://sus.mycompany.corp/content/catalogs/others/index-10.12seed-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz
+
+**OS X v10.13**
+
+    https://sus.mycompany.corp/content/catalogs/others/index-10.13beta-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz
+
 ### Running Software Update on Computers
 
 For instructions on using the Casper Suite to run Software Update on computers that are managed by the JSS, see the “Running Software Update” section in the Casper Suite Administrator’s Guide.

--- a/docs/sus.md
+++ b/docs/sus.md
@@ -127,11 +127,11 @@ Branch URLs vary depending on the operating system of enrolled computers. Exampl
 	
 **OS X v10.12**
 
-    https://sus.mycompany.corp/content/catalogs/others/index-10.12seed-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz
+    https://sus.mycompany.corp/content/catalogs/others/index-10.12seed-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1_<Branch Name>.sucatalog.gz
 
 **OS X v10.13**
 
-    https://sus.mycompany.corp/content/catalogs/others/index-10.13beta-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz
+    https://sus.mycompany.corp/content/catalogs/others/index-10.13beta-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1_<Branch Name>.sucatalog.gz
 
 ### Running Software Update on Computers
 


### PR DESCRIPTION
I believe there was 2 branchURLs missing in the documentation.

Sierra v10.12
https://swscan.apple.com/content/catalogs/others/index-10.12seed-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz

High Sierra v10.13
https://swscan.apple.com/content/catalogs/others/index-10.13beta-10.13-10.12-10.11-10.10-10.9-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog.gz

Have a good day 😄 