### PR TITLE
Stop code execution if user is not authenticated

### DIFF
--- a/webadmin/var/www/webadmin/inc/auth.php
+++ b/webadmin/var/www/webadmin/inc/auth.php
@@ -4,6 +4,7 @@ session_start();
 $noAuthURL="index.php";
 if (!($_SESSION['isAuthUser'])) {
 	header('Location: '. $noAuthURL);
+	exit;
 }
 
 ?>


### PR DESCRIPTION
Without an exit statement after the 302 response header is set, all code after including this file, will be executed. 

This is a **major security vulnerability**, because one would be able to, for example:
- Add system users
- Change the password of existing users
- Enable/disable SSH
- Enable/disable the firewall

as an unauthenticated user.